### PR TITLE
ci: fix release-please baseline and tag format

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "e1d52790eaf62082dec9a1fa7f62105cdb13a4bd",
   "packages": {
     ".": {
       "release-type": "node",
+      "include-component-in-tag": false,
+      "include-v-in-tag": false,
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,


### PR DESCRIPTION
# Description

Fixes the release-please configuration so it anchors on the 2.2.0 baseline
instead of sweeping all history into the first release PR (#23).

- `include-component-in-tag: false` — drops the `finance-app-` tag prefix
- `include-v-in-tag: false` — tags like `2.3.0`, matching existing history (`1.1.8`)
- `bootstrap-sha` — pins the first release to start after the 2.2.0 baseline

The `v2.2.0` tag was also retagged to `2.2.0` to match the project convention.

## Type of change

- [ ] `feat` — new feature (minor version bump)
- [ ] `fix` — bug fix (patch version bump)
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
- [x] `chore` — tooling, config, dependencies
- [ ] Breaking change (`!` / `BREAKING CHANGE:` — major version bump)

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] `npm run typecheck` passes
- [ ] I tested the change on a device/emulator — N/A (tooling only)