### PR TITLE
ci: validate PR titles as conventional commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,34 @@
+name: PR Title
+
+# Validates that the PR title is a valid Conventional Commit. Because PRs are
+# squash-merged with the PR title as the commit message, the title is what
+# drives release-please versioning — so it must follow the convention.
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Keep in sync with commitlint (@commitlint/config-conventional)
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert


### PR DESCRIPTION
# Description

Adds a CI check (`amannn/action-semantic-pull-request`) that fails when a PR title is not a valid Conventional Commit. Since the repo now squash-merges with the PR title as the commit message, the title drives release-please versioning — this closes the gap where husky lints individual commits but not the final squash title. Types are kept in sync with `@commitlint/config-conventional`.

## Type of change

- [ ] `feat` — new feature (minor version bump)
- [ ] `fix` — bug fix (patch version bump)
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
- [x] `chore` — tooling, config, dependencies
- [ ] Breaking change (`!` / `BREAKING CHANGE:` — major version bump)

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] `npm run typecheck` passes
- [ ] I tested the change on a device/emulator — N/A (tooling only)