### PR TITLE
feat: notify user with a toast when an OTA update is ready

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import SecurityGuard from './src/components/SecurityGuard';
 import { AppContextProvider } from './src/contexts/AppContext';
 import { AuthContextProvider } from './src/contexts/AuthContext';
 import { BottomSheetContextProvider } from './src/contexts/BottomSheetContext';
+import useAppUpdates from './src/hooks/useAppUpdates';
 import Routes from './src/routes';
 import dark from './src/theme/dark';
 import light from './src/theme/light';
@@ -32,6 +33,8 @@ export default function App() {
   const colorScheme = useColorScheme();
 
   const theme = colorScheme === 'dark' ? dark : light;
+
+  useAppUpdates();
 
   useEffect(() => {
     if (fontsLoaded) {

--- a/src/hooks/useAppUpdates.ts
+++ b/src/hooks/useAppUpdates.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
+import Toast from 'react-native-toast-message';
+import * as Updates from 'expo-updates';
+
+const useAppUpdates = () => {
+  const appState = useRef(AppState.currentState);
+
+  const checkForUpdate = useCallback(async () => {
+    if (!Updates.isEnabled || __DEV__) {
+      return;
+    }
+
+    try {
+      const { isAvailable } = await Updates.checkForUpdateAsync();
+
+      if (!isAvailable) {
+        return;
+      }
+
+      await Updates.fetchUpdateAsync();
+
+      Toast.show({
+        type: 'info',
+        text1: 'Nova atualização disponível',
+        text2: 'Toque aqui para aplicar agora',
+        autoHide: false,
+        onPress: () => {
+          Toast.hide();
+          Updates.reloadAsync();
+        },
+      });
+    } catch (error) {
+      // Ignore update check/fetch failures, app keeps running on the current version.
+    }
+  }, []);
+
+  useEffect(() => {
+    checkForUpdate();
+
+    const subscription = AppState.addEventListener('change', (nextAppState: AppStateStatus) => {
+      if (appState.current.match(/inactive|background/) && nextAppState === 'active') {
+        checkForUpdate();
+      }
+
+      appState.current = nextAppState;
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [checkForUpdate]);
+};
+
+export default useAppUpdates;


### PR DESCRIPTION
# Description

Checks for OTA updates on app launch and whenever the app returns to the foreground (`AppState` change to `active`). When an update is found and downloaded, shows a persistent toast prompting the user to tap to reload immediately, instead of relying on it applying silently on the next natural app restart (previously the only way to confirm an OTA push landed was to close and reopen the app).

No-op when `expo-updates` is disabled or in dev (`__DEV__`), so local/Expo Go development is unaffected.

## Type of change

- [x] `feat` — new feature (minor version bump)
- [ ] `fix` — bug fix (patch version bump)
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
- [ ] `chore` — tooling, config, dependencies
- [ ] Breaking change (`!` / `BREAKING CHANGE:` — major version bump)

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `npm run lint` passes
- [x] `npm run format` passes
- [x] `npm run typecheck` passes
- [ ] I tested the change on a device/emulator